### PR TITLE
feat: enhance boolean element with toggle switch UI

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -6,6 +6,9 @@ Auto-generated from all feature plans. Last updated: 2025-12-26
 - TypeScript 5.9, React 18+ + `lucide-react` (new), `survey-core`, `motion`, `@radix-ui/*` (002-feature-implement-details)
 - TypeScript 5.x + React 18, survey-core, motion/react, @radix-ui/react-* (003-feature-support-drag)
 - N/A (SurveyJS Model State) (003-feature-support-drag)
+- TypeScript 5.x + React, SurveyJS (survey-core), Radix UI, motion/reac (004-enhancement-boolean-type-element)
+- TypeScript ~5.9.3 + React >=18, survey-core ^2.5.0, motion ^12.0.0, @radix-ui/react-switch (004-enhancement-boolean-type-element)
+- TypeScript 5.x + React 18+, SurveyJS (survey-core), Radix UI, motion/reac (004-enhancement-boolean-type-element)
 
 - TypeScript 5.x + React, survey-core, motion/react, Radix UI (001-fix-make-choices)
 
@@ -25,9 +28,9 @@ npm test && npm run lint
 TypeScript 5.x: Follow standard conventions
 
 ## Recent Changes
-- 003-feature-support-drag: Added TypeScript 5.x + React 18, survey-core, motion/react, @radix-ui/react-*
-- 003-feature-support-drag: Added [if applicable, e.g., PostgreSQL, CoreData, files or N/A]
-- 002-feature-implement-details: Added TypeScript 5.9, React 18+ + `lucide-react` (new), `survey-core`, `motion`, `@radix-ui/*`
+- 004-enhancement-boolean-type-element: Added TypeScript 5.x + React 18+, SurveyJS (survey-core), Radix UI, motion/reac
+- 004-enhancement-boolean-type-element: Added TypeScript ~5.9.3 + React >=18, survey-core ^2.5.0, motion ^12.0.0, @radix-ui/react-switch
+- 004-enhancement-boolean-type-element: Added TypeScript 5.x + React, SurveyJS (survey-core), Radix UI, motion/reac
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist-ssr
 *.sw?
 specs/
 .env
+coverage/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+src/
+node_modules/
+.git/
+.github/
+specs/
+tests/
+*.log
+.DS_Store
+tsconfig*.json
+vite.config.ts
+vitest.config.ts
+eslint.config.js

--- a/src/lib/__tests__/BooleanElement.test.tsx
+++ b/src/lib/__tests__/BooleanElement.test.tsx
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BooleanElement } from '../elements/types/BooleanElement'
+import { Question } from 'survey-core'
+import { RenderOptions } from '../ui/types'
+
+// Helper to setup userEvent
+function setup(jsx: React.ReactElement) {
+  return {
+    user: userEvent.setup(),
+    ...render(jsx),
+  }
+}
+
+describe('BooleanElement', () => {
+  let question: Question
+  const opts: RenderOptions = {
+    duration: 0.2,
+    validationSeq: 0,
+  }
+
+  beforeEach(() => {
+    question = new Question('bool_q')
+    question.title = 'Yes or No?'
+  })
+
+  it('renders as a toggle switch with Yes/No options', () => {
+    render(<BooleanElement question={question} opts={opts} />)
+    
+    // Should find the toggle switch container
+    const switchContainer = document.querySelector('.msj__toggleSwitch')
+    expect(switchContainer).toBeInTheDocument()
+
+    // Should find the track and handle
+    const track = document.querySelector('.msj__toggleTrack')
+    const handle = document.querySelector('.msj__toggleHandle')
+    expect(track).toBeInTheDocument()
+    expect(handle).toBeInTheDocument()
+
+    // Should find Yes and No labels (hidden or visible depending on state)
+    // Since we are using RadioGroup, we should still find the radio items
+    const yesButton = screen.getByRole('radio', { name: 'Yes' })
+    const noButton = screen.getByRole('radio', { name: 'No' })
+    
+    expect(yesButton).toBeInTheDocument()
+    expect(noButton).toBeInTheDocument()
+  })
+
+  it('updates value when options are clicked', async () => {
+    const { user } = setup(<BooleanElement question={question} opts={opts} />)
+    
+    const yesButton = screen.getByRole('radio', { name: 'Yes' })
+    await user.click(yesButton)
+    expect(question.value).toBe(true)
+    
+    const noButton = screen.getByRole('radio', { name: 'No' })
+    await user.click(noButton)
+    expect(question.value).toBe(false)
+  })
+
+  it('supports keyboard navigation and ARIA roles', async () => {
+    const { user } = setup(<BooleanElement question={question} opts={opts} />)
+    
+    // Should have radiogroup role
+    const group = screen.getByRole('radiogroup')
+    expect(group).toBeInTheDocument()
+    
+    const yesButton = screen.getByRole('radio', { name: 'Yes' })
+    const noButton = screen.getByRole('radio', { name: 'No' })
+    
+    // Initial state
+    expect(yesButton).toHaveAttribute('aria-checked', 'false')
+    expect(noButton).toHaveAttribute('aria-checked', 'false')
+    
+    // Click Yes
+    await user.click(yesButton)
+    expect(yesButton).toHaveAttribute('aria-checked', 'true')
+    expect(noButton).toHaveAttribute('aria-checked', 'false')
+    
+    // Keyboard navigation (Arrow keys)
+    // Focus Yes (currently selected)
+    yesButton.focus()
+    
+    // Arrow Right -> Should select No (or focus No)
+    await user.keyboard('{ArrowRight}')
+    
+    // Check if No is focused
+    expect(noButton).toHaveFocus()
+    
+    // If selection follows focus, value should be false.
+    // If not, we might need to press Space.
+    // Radix RadioGroup default behavior: selection follows focus.
+    // But let's check if it updated.
+    if (question.value !== false) {
+        // If not updated, maybe we need to press Space?
+        // Or maybe user-event needs something else.
+        // Let's try pressing Space to confirm it works.
+        await user.keyboard(' ')
+    }
+    
+    expect(question.value).toBe(false)
+    expect(noButton).toHaveAttribute('aria-checked', 'true')
+    
+    // Arrow Left -> Should select Yes
+    await user.keyboard('{ArrowLeft}')
+    // Again, check focus and value
+    expect(yesButton).toHaveFocus()
+    if (question.value !== true) {
+        await user.keyboard(' ')
+    }
+    expect(question.value).toBe(true)
+    expect(yesButton).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('supports custom labels and values', async () => {
+    const q2 = new Question('bool_q2')
+    q2.title = 'Agree?'
+    // @ts-ignore
+    q2.labelTrue = 'Agree'
+    // @ts-ignore
+    q2.labelFalse = 'Disagree'
+    // @ts-ignore
+    q2.valueTrue = 'Yes'
+    // @ts-ignore
+    q2.valueFalse = 'No'
+    
+    const { user } = setup(<BooleanElement question={q2} opts={opts} />)
+    
+    const agreeBtn = screen.getByRole('radio', { name: 'Agree' })
+    const disagreeBtn = screen.getByRole('radio', { name: 'Disagree' })
+    
+    expect(agreeBtn).toBeInTheDocument()
+    expect(disagreeBtn).toBeInTheDocument()
+    
+    await user.click(agreeBtn)
+    expect(q2.value).toBe('Yes')
+    
+    await user.click(disagreeBtn)
+    expect(q2.value).toBe('No')
+  })
+
+  it('respects swapOrder property', () => {
+     const q3 = new Question('bool_q3')
+     // @ts-ignore
+     q3.swapOrder = true
+     
+     render(<BooleanElement question={q3} opts={opts} />)
+     
+     const radios = screen.getAllByRole('radio')
+     // Default implementation renders False (No) then True (Yes)
+     // With swapOrder, it should be True (Yes) then False (No)
+     
+     // Since radios are visually hidden and use aria-label
+     expect(radios[0]).toHaveAttribute('aria-label', 'Yes')
+     expect(radios[1]).toHaveAttribute('aria-label', 'No')
+     
+     // Also verify visible track labels
+     const trackLabels = document.querySelectorAll('.msj__toggleTrackLabel')
+     expect(trackLabels[0]).toHaveTextContent('Yes')
+     expect(trackLabels[1]).toHaveTextContent('No')
+  })
+})

--- a/src/style.css
+++ b/src/style.css
@@ -9,6 +9,15 @@
   --msj-primary: #2563eb;
   --msj-primary-contrast: #ffffff;
   --msj-radius: 10px;
+
+  /* Boolean Element Colors */
+  --msj-boolean-true-bg: color-mix(in srgb, var(--msj-primary) 14%, white);
+  --msj-boolean-true-text: var(--msj-primary);
+  --msj-boolean-true-border: color-mix(in srgb, var(--msj-primary) 35%, var(--msj-border));
+  
+  --msj-boolean-false-bg: #f1f5f9;
+  --msj-boolean-false-text: #475569;
+  --msj-boolean-false-border: #cbd5e1;
 }
 
 .msj--theme-modern {
@@ -636,6 +645,121 @@
   position: relative;
   z-index: 1;
   font-weight: 600;
+}
+
+/* Boolean Element Specifics */
+.msj__buttonGroupItem--true.msj__buttonGroupItem--active {
+  border-color: var(--msj-boolean-true-border);
+  color: var(--msj-boolean-true-text);
+}
+
+.msj__buttonGroupItem--true .msj__buttonGroupItemBg {
+  background: var(--msj-boolean-true-bg);
+}
+
+.msj__buttonGroupItem--false.msj__buttonGroupItem--active {
+  border-color: var(--msj-boolean-false-border);
+  color: var(--msj-boolean-false-text);
+}
+
+.msj__buttonGroupItem--false .msj__buttonGroupItemBg {
+  background: var(--msj-boolean-false-bg);
+}
+
+/* Toggle Switch */
+.msj__toggleSwitch {
+  position: relative;
+  width: 100%;
+  max-width: 320px;
+  height: 48px;
+  border-radius: 999px;
+  background: var(--msj-bg);
+  border: 1px solid var(--msj-border);
+  user-select: none;
+  box-sizing: border-box;
+}
+
+.msj__toggleTrack {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 20px;
+  pointer-events: none;
+}
+
+.msj__toggleTrackLabel {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--msj-muted);
+  z-index: 0;
+  width: 50%;
+  text-align: center;
+}
+
+.msj__toggleTrackLabel--left {
+  text-align: center; /* Or left? Center of the half seems better */
+  transform: translateX(-10px); /* Adjust for padding? */
+}
+
+.msj__toggleTrackLabel--right {
+  text-align: center;
+  transform: translateX(10px);
+}
+
+.msj__toggleHandle {
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  width: calc(50% - 6px);
+  background: white;
+  border-radius: 999px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.08);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 14px;
+  z-index: 1;
+  color: var(--msj-text);
+  border: 1px solid var(--msj-border);
+  box-sizing: border-box;
+}
+
+.msj__toggleHandle--true {
+  background: var(--msj-boolean-true-bg);
+  color: var(--msj-boolean-true-text);
+  border-color: var(--msj-boolean-true-border);
+}
+
+.msj__toggleHandle--false {
+  background: var(--msj-boolean-false-bg);
+  color: var(--msj-boolean-false-text);
+  border-color: var(--msj-boolean-false-border);
+}
+
+.msj__toggleInputs {
+  position: absolute;
+  inset: 0;
+  display: flex;
+}
+
+.msj__toggleInput {
+  flex: 1;
+  opacity: 0.001;
+  cursor: pointer;
+  margin: 0;
+  appearance: none;
+  background: transparent;
+  border: none;
+  color: transparent;
+  border-radius: 999px; /* For focus ring shape if we used outline on input */
+}
+
+.msj__toggleSwitch:has(.msj__toggleInput:focus-visible) {
+  outline: 2px solid var(--msj-primary);
+  outline-offset: 2px;
 }
 
 .msj__imagePicker {


### PR DESCRIPTION
This PR implements the iPhone-style toggle switch for the boolean element, resolving issue #12.

**Changes:**
- Refactored `BooleanElement` to use a toggle switch UI instead of radio buttons.
- Implemented smooth sliding animations using `motion/react`.
- Added support for custom labels (`labelTrue`, `labelFalse`) and values.
- Added support for `swapOrder`.
- Ensured accessibility with keyboard navigation and ARIA roles.
- Styled the switch to match the theme (Primary color for Yes, Dim for No).
- Fixed mobile scroll issues by keeping inputs layout-relevant.

**Verification:**
- Added unit tests in `src/lib/__tests__/BooleanElement.test.tsx`.
- Verified all tests pass.