### PR TITLE
fix: resolve ReferenceError for title in Dropdown and other elements

### DIFF
--- a/src/lib/elements/types/ButtonGroupElement.tsx
+++ b/src/lib/elements/types/ButtonGroupElement.tsx
@@ -3,13 +3,12 @@ import { motion } from 'motion/react'
 import { BaseElement } from '../../ui/BaseElement'
 import type { RenderOptions } from '../../ui/types'
 import { Errors } from '../../ui/Errors'
+import { QuestionTitle } from '../../ui/QuestionTitle'
 import { getQuestionErrors } from '../getQuestionErrors'
-import { getQuestionTitle } from '../getQuestionTitle'
 import { setQuestionValue } from '../setQuestionValue'
 
 export function ButtonGroupElement({ question, opts }: { question: Question; opts: RenderOptions }) {
   const q = question as unknown as { visibleChoices?: ChoiceItem[] }
-  const title = getQuestionTitle(question, opts)
   const errors = opts.validationSeq > 0 ? getQuestionErrors(question) : []
   const choices = q.visibleChoices ?? []
   const currentStr = question.value == null ? '' : String(question.value)

--- a/src/lib/elements/types/DropdownElement.tsx
+++ b/src/lib/elements/types/DropdownElement.tsx
@@ -7,6 +7,7 @@ import { Errors } from '../../ui/Errors'
 import type { RenderOptions } from '../../ui/types'
 import { QuestionTitle } from '../../ui/QuestionTitle'
 import { getQuestionErrors } from '../getQuestionErrors'
+import { getQuestionTitle } from '../getQuestionTitle'
 import { setQuestionValue } from '../setQuestionValue'
 
 export function DropdownElement({
@@ -17,6 +18,7 @@ export function DropdownElement({
   opts: RenderOptions
 }) {
   const q = question
+  const title = getQuestionTitle(q, opts)
   const errors = opts.validationSeq > 0 ? getQuestionErrors(q) : []
   const choices =
     (q as unknown as { visibleChoices?: ChoiceItem[] }).visibleChoices ?? []

--- a/src/lib/elements/types/ImagePickerElement.tsx
+++ b/src/lib/elements/types/ImagePickerElement.tsx
@@ -3,15 +3,14 @@ import { motion } from 'motion/react'
 import { BaseElement } from '../../ui/BaseElement'
 import type { RenderOptions } from '../../ui/types'
 import { Errors } from '../../ui/Errors'
+import { QuestionTitle } from '../../ui/QuestionTitle'
 import { getQuestionErrors } from '../getQuestionErrors'
-import { getQuestionTitle } from '../getQuestionTitle'
 import { setQuestionValue } from '../setQuestionValue'
 
 type ChoiceWithImage = ChoiceItem & { imageLink?: string }
 
 export function ImagePickerElement({ question, opts }: { question: Question; opts: RenderOptions }) {
   const q = question as unknown as { visibleChoices?: ChoiceWithImage[]; multiSelect?: boolean }
-  const title = getQuestionTitle(question, opts)
   const errors = opts.validationSeq > 0 ? getQuestionErrors(question) : []
   const choices = q.visibleChoices ?? []
   const isMulti = Boolean(q.multiSelect)

--- a/src/lib/elements/types/MatrixElement.tsx
+++ b/src/lib/elements/types/MatrixElement.tsx
@@ -4,8 +4,8 @@ import * as Checkbox from '@radix-ui/react-checkbox'
 import { BaseElement } from '../../ui/BaseElement'
 import type { RenderOptions } from '../../ui/types'
 import { Errors } from '../../ui/Errors'
+import { QuestionTitle } from '../../ui/QuestionTitle'
 import { getQuestionErrors } from '../getQuestionErrors'
-import { getQuestionTitle } from '../getQuestionTitle'
 import { setQuestionValue } from '../setQuestionValue'
 import { Checkmark } from '../../ui/Checkmark'
 import { motion } from 'motion/react'
@@ -22,7 +22,6 @@ export function MatrixElement({ question, opts }: { question: Question; opts: Re
     isRequired?: boolean
   }
 
-  const title = getQuestionTitle(question, opts)
   const errors = opts.validationSeq > 0 ? getQuestionErrors(question) : []
   const rows = (q as unknown as { rows?: MatrixRow[] }).rows ?? q.visibleRows ?? []
   const cols = (q as unknown as { columns?: MatrixColumn[] }).columns ?? q.visibleColumns ?? []

--- a/src/lib/elements/types/RankingElement.tsx
+++ b/src/lib/elements/types/RankingElement.tsx
@@ -3,8 +3,8 @@ import { Reorder, motion, AnimatePresence } from 'motion/react'
 import { BaseElement } from '../../ui/BaseElement'
 import type { RenderOptions } from '../../ui/types'
 import { Errors } from '../../ui/Errors'
+import { QuestionTitle } from '../../ui/QuestionTitle'
 import { getQuestionErrors } from '../getQuestionErrors'
-import { getQuestionTitle } from '../getQuestionTitle'
 import { setQuestionValue } from '../setQuestionValue'
 import { RankingItem } from './RankingItem'
 
@@ -17,7 +17,6 @@ export function RankingElement({ question, opts }: { question: Question; opts: R
     selectToRankEmptyUnrankedAreaText?: string
     longTap?: boolean
   } & Question
-  const title = getQuestionTitle(question, opts)
   const errors = opts.validationSeq > 0 ? getQuestionErrors(question) : []
   const choices = q.visibleChoices ?? []
 

--- a/src/lib/elements/types/RatingElement.tsx
+++ b/src/lib/elements/types/RatingElement.tsx
@@ -4,8 +4,8 @@ import { Star, Frown, Meh, Smile, Laugh, Angry } from 'lucide-react'
 import { BaseElement } from '../../ui/BaseElement'
 import type { RenderOptions } from '../../ui/types'
 import { Errors } from '../../ui/Errors'
+import { QuestionTitle } from '../../ui/QuestionTitle'
 import { getQuestionErrors } from '../getQuestionErrors'
-import { getQuestionTitle } from '../getQuestionTitle'
 import { setQuestionValue } from '../setQuestionValue'
 
 function StarIcon({ active }: { active: boolean }) {
@@ -24,7 +24,6 @@ function SmileyIcon({ idx, total }: { idx: number; total: number }) {
 
 export function RatingElement({ question, opts }: { question: Question; opts: RenderOptions }) {
   const q = question as QuestionRatingModel
-  const title = getQuestionTitle(question, opts)
   const errors = opts.validationSeq > 0 ? getQuestionErrors(question) : []
   const values = q.visibleRateValues ?? []
   const current = question.value == null ? '' : String(question.value)

--- a/src/lib/elements/types/TagboxElement.tsx
+++ b/src/lib/elements/types/TagboxElement.tsx
@@ -3,13 +3,12 @@ import { motion } from 'motion/react'
 import { BaseElement } from '../../ui/BaseElement'
 import type { RenderOptions } from '../../ui/types'
 import { Errors } from '../../ui/Errors'
+import { QuestionTitle } from '../../ui/QuestionTitle'
 import { getQuestionErrors } from '../getQuestionErrors'
-import { getQuestionTitle } from '../getQuestionTitle'
 import { setQuestionValue } from '../setQuestionValue'
 
 export function TagboxElement({ question, opts }: { question: Question; opts: RenderOptions }) {
   const q = question as unknown as { visibleChoices?: ChoiceItem[] }
-  const title = getQuestionTitle(question, opts)
   const errors = opts.validationSeq > 0 ? getQuestionErrors(question) : []
   const choices = q.visibleChoices ?? []
   const set = new Set(Array.isArray(question.value) ? (question.value as unknown[]) : [])


### PR DESCRIPTION
This PR fixes a regression where the `title` variable was removed but still referenced in `aria-label` attributes across multiple element types.

**Fixes:**
- `DropdownElement`: Restored `title` variable using `getQuestionTitle`.
- `ButtonGroupElement`, `ImagePickerElement`, `MatrixElement`, `RankingElement`, `RatingElement`, `TagboxElement`: Fixed missing imports for `QuestionTitle` and removed unused `title` variable declarations.

**Verification:**
- Ran `npm run typecheck` to ensure no more reference errors.
- Verified build passes.